### PR TITLE
fix: replace curl with wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ ENV HOSTNAME="0.0.0.0"
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8000/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8000/ || exit 1
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
@ejsadiarin  Removed curl in favor of wget and temporarily changed the ping target from health to the root using localhost. The container might be crashing due to wrong OS tools (curl not native) or unbuilt endpoints (/health)