### PR TITLE
refactor(api): make image signed URL endpoint public

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -71,12 +71,14 @@ async function seedDatabase() {
           description: funcs.loremIpsum({ sentencesCount: 2 }),
           url: funcs.string(),
           githubLink: funcs.string(),
+          previewImages: funcs.default({ defaultValue: null }),
+          icon: funcs.default({ defaultValue: null }),
           tags: funcs.valuesFromArray({
             values: ['web', 'mobile', 'api', 'ai', 'iot', 'design'],
             arraySize: 3,
           }),
           status: funcs.valuesFromArray({
-            values: ['APPROVED', 'PENDING', 'REJECTED', 'REMOVED'],
+            values: ['APPROVED', 'PENDING', 'CHANGES_REQUESTED', 'REMOVED'],
           }),
           rejectionReason: funcs.valuesFromArray({
             values: [null, null, null, 'Needs better screenshots', 'Insufficient description'],

--- a/src/images/images.routes.ts
+++ b/src/images/images.routes.ts
@@ -1,3 +1,4 @@
+
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'node:crypto';
@@ -9,6 +10,8 @@ import { HttpError } from '@/shared/middleware/error.middleware.js';
 import { S3ImageQuerySchema, S3PresignedUploadQuerySchema } from './dto/index.js';
 
 const router = Router();
+
+const ALLOWED_PREFIXES = ['preview-images/', 'icons/'];
 
 const contentTypeToExt: Record<string, string> = {
   'image/jpeg': 'jpg',
@@ -44,8 +47,12 @@ router.get(
   },
 );
 
-router.get('/signed', requireAuth, async (req: Request, res: Response): Promise<void> => {
+router.get('/signed', async (req: Request, res: Response): Promise<void> => {
   const { key } = S3ImageQuerySchema.parse(req.query);
+
+  if (!ALLOWED_PREFIXES.some((p) => key.startsWith(p))) {
+    throw new HttpError(400, 'Invalid key', 'INVALID_KEY');
+  }
 
   const bucket = process.env.S3_BUCKET;
   if (!bucket) {


### PR DESCRIPTION
## Summary

Makes `GET /api/images/signed` publicly accessible by removing the `requireAuth` middleware from that route. Images are displayed to all visitors (including unauthenticated users), so requiring a session to fetch a signed read URL was incorrect and caused images to fail for logged-out users.

To compensate for the removed authentication guard, a key prefix whitelist (`preview-images/`, `icons/`) is enforced on the `key` query parameter. This prevents the public endpoint from being used to generate signed URLs for arbitrary S3 objects outside of the known image directories.

This change is the backend half of a larger refactor that moves all S3 signing responsibility from the frontend to the API, eliminating the need for S3 credentials in the frontend deployment.

## Linked Issues

closes #

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- **`requireAuth` was removed** from `GET /api/images/signed` only. The upload presigned URL endpoint (`GET /api/images/uploads/presigned`) retains `requireAuth` — only authenticated users can upload.
- **`ALLOWED_PREFIXES`** (`['preview-images/', 'icons/']`) is validated immediately after query parsing. Any key outside these prefixes returns `400 INVALID_KEY`. This matches the same whitelist that the now-deleted frontend `/api/signed` route enforced.
- No new endpoints, no schema changes, no new dependencies.
- The frontend will now route all image reads through this endpoint. Ensure the backend is reachable from the frontend deployment (CORS, network policy, etc.).