### PR TITLE
 feat: add admin permanent delete endpoint for removed applications

### DIFF
--- a/src/applications/application.controller.ts
+++ b/src/applications/application.controller.ts
@@ -199,6 +199,22 @@ export class ApplicationController {
   };
 
   /**
+   * Handles DELETE requests for permanently deleting a REMOVED application (Admin only)
+   * @route DELETE /api/applications/admin/:id
+   */
+  permanentlyDeleteApplicationById = async (req: Request, res: Response): Promise<void> => {
+    const { id } = ApplicationIdParamsSchema.parse(req.params);
+
+    logger.debug('Permanently deleting application', { id });
+
+    await this.applicationService.permanentlyDeleteApplicationById(id);
+
+    logger.info('Application permanently deleted', { id });
+
+    res.status(204).send();
+  };
+
+  /**
    * Handles PATCH requests for admin review (approve/reject) of an application
    * @route PATCH /api/applications/admin/:id/review
    */

--- a/src/applications/application.routes.ts
+++ b/src/applications/application.routes.ts
@@ -31,6 +31,18 @@ router.post('/', requireAuth, applicationController.createApplication);
 router.patch('/:id', requireAuth, applicationController.patchApplicationById);
 
 /**
+ * @route DELETE /api/applications/admin/:id
+ * @description Permanently delete a REMOVED application and its S3 media (Admin only)
+ * @access Private (Admin only)
+ */
+router.delete(
+  '/admin/:id',
+  requireAuth,
+  requireRole('admin'),
+  applicationController.permanentlyDeleteApplicationById,
+);
+
+/**
  * @route DELETE /api/applications/:id
  * @description Delete an application by ID
  * @access Private

--- a/src/applications/application.service.ts
+++ b/src/applications/application.service.ts
@@ -39,6 +39,7 @@ import {
 import type { ReviewApplicationRequest } from './dto/review-application-request.dto.js';
 import { getDbErrorMessage } from '@/shared/utils/dbErrorUtils.js';
 import { assertOwnershipOrAdmin } from '../shared/utils/auth.utils.js';
+import { deleteS3ImageObjects } from '@/shared/infrastructure/s3/image-cleanup.js';
 
 export interface IApplicationService {
   getPaginatedApplications(
@@ -63,6 +64,7 @@ export interface IApplicationService {
   ): Promise<string>;
   reviewAdminApplicationById(id: number, input: ReviewApplicationRequest): Promise<void>;
   deleteApplicationById(id: number, actorUserId: string): Promise<void>;
+  permanentlyDeleteApplicationById(id: number): Promise<void>;
   getUserByApplicationId(appId: number): Promise<{
     id: string;
     email: string;
@@ -438,6 +440,31 @@ export default class ApplicationService implements IApplicationService {
         rejectionReason: 'Deleted by owner',
       })
       .where(eq(application.id, id));
+  };
+
+  permanentlyDeleteApplicationById = async (id: number): Promise<void> => {
+    const [existing] = await this.db
+      .select({
+        id: application.id,
+        status: application.status,
+        icon: application.icon,
+        previewImages: application.previewImages,
+      })
+      .from(application)
+      .where(eq(application.id, id))
+      .limit(1);
+
+    if (!existing) {
+      throw new HttpError(404, 'Application not found', 'NOT_FOUND');
+    }
+
+    if (existing.status !== 'REMOVED') {
+      throw new HttpError(400, 'Only REMOVED applications can be permanently deleted', 'INVALID_STATUS');
+    }
+
+    await deleteS3ImageObjects([existing.icon, ...(existing.previewImages ?? [])]);
+
+    await this.db.delete(application).where(eq(application.id, id));
   };
 
   getUserByApplicationId = async (


### PR DESCRIPTION
## Summary

Adds a new admin-only endpoint `DELETE /api/applications/admin/:id` that permanently removes an application from the database and deletes all associated S3 assets (icon + preview images). The endpoint enforces a status guard. Only applications in `REMOVED` status can be permanently deleted, preventing accidental destruction of live or pending apps. The service layer runs S3 cleanup via `deleteS3ImageObjects` before the database delete to avoid orphaned files.

## Linked Issues

N/A

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- Only apps with status `REMOVED` can be permanently deleted; any other status throws `HttpError` with code `INVALID_STATUS`
- S3 cleanup runs **before** the DB delete, if S3 deletion fails, the DB row is not deleted
- Endpoint is gated behind admin role middleware, unauthenticated or non-admin requests are rejected before reaching the controller