### PR TITLE
Feat/admin patch

### DIFF
--- a/src/applications/application.service.ts
+++ b/src/applications/application.service.ts
@@ -333,6 +333,22 @@ export default class ApplicationService implements IApplicationService {
       setPayload.status = 'PENDING';
     }
 
+    // Collect replaced S3 keys so they can be deleted after the DB update succeeds.
+    const orphanedKeys: Array<string | null | undefined> = [];
+
+    if (updates.icon !== undefined && updates.icon !== current.icon) {
+      orphanedKeys.push(current.icon);
+    }
+
+    if (updates.previewImages !== undefined) {
+      const incoming = new Set(updates.previewImages ?? []);
+      for (const key of current.previewImages ?? []) {
+        if (!incoming.has(key)) {
+          orphanedKeys.push(key);
+        }
+      }
+    }
+
     let patched: { slug: string } | undefined;
 
     try {
@@ -351,6 +367,10 @@ export default class ApplicationService implements IApplicationService {
 
     if (!patched) {
       throw new HttpError(404, 'Application not found', 'NOT_FOUND');
+    }
+
+    if (orphanedKeys.length > 0) {
+      await deleteS3ImageObjects(orphanedKeys);
     }
 
     return patched.slug;

--- a/src/applications/application.service.ts
+++ b/src/applications/application.service.ts
@@ -329,7 +329,7 @@ export default class ApplicationService implements IApplicationService {
       ...updates,
     };
 
-    if (current.status === 'CHANGES_REQUESTED') {
+    if (current.status === 'CHANGES_REQUESTED' || current.status === 'APPROVED') {
       setPayload.status = 'PENDING';
     }
 


### PR DESCRIPTION
# feat(applications):admin patch for removed apps

## Summary

- **S3 image cleanup on delete** : when an application is deleted, the service now fetches the existing record, extracts `icon` and `previewImages` S3 keys, and calls a new `deleteS3ImageObjects` bulk-delete helper (`src/shared/infrastructure/s3/image-cleanup.ts`) to remove the associated objects from the bucket.
- **App status logic on edit**: when a non-admin author patches their application, the status is now correctly reset to `pending` for re-review instead of remaining `approved`.

## Linked Issues

N/A

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers
