### PR TITLE
feat: Add Popularity-Based Sorting Options

### DIFF
--- a/drizzle/20260819000000_add_view_count_to_application/migration.sql
+++ b/drizzle/20260819000000_add_view_count_to_application/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "application" ADD COLUMN "view_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX "application_view_count_idx" ON "application" ("view_count");

--- a/src/applications/application.controller.ts
+++ b/src/applications/application.controller.ts
@@ -292,6 +292,22 @@ export class ApplicationController {
   };
 
   /**
+   * Handles POST requests to increment view count for an application by slug
+   * @route POST /api/applications/:slug/view
+   */
+  incrementViewCount = async (req: Request, res: Response): Promise<void> => {
+    const { slug } = ApplicationSlugParamsSchema.parse(req.params);
+
+    logger.debug('Incrementing view count', { slug });
+
+    await this.applicationService.incrementViewCount(slug);
+
+    logger.info('Application view count incremented', { slug });
+
+    res.status(204).send();
+  };
+
+  /**
    * List all claim requests (admin)
    * @route GET /api/applications/admin/claims
    */

--- a/src/applications/application.openapi.ts
+++ b/src/applications/application.openapi.ts
@@ -432,3 +432,54 @@ registry.registerPath({
     },
   },
 });
+
+/**
+ * Reguster the POST /api/applications/{slug}/view endpoint
+ */
+registry.registerPath({
+  method: 'post',
+  path: '/api/applications/{slug}/view',
+  description: 'Increment view count for an approved application by slug (Rate limited to 1 per IP per minute per app)',
+  summary: 'Increment application view count',
+  tags: ['Applications'],
+  request: {
+    params: ApplicationSlugParamsSchema,
+  },
+  responses: {
+    204: {
+      description: 'View count incremented successfully',
+    },
+    400: {
+      description: 'Invalid slug parameter - VALIDATION_ERROR',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Application not found - NOT_FOUND',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    429: {
+      description: 'Too many requests - RATE_LIMITED',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: 'Internal server error - INTERNAL_ERROR',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});

--- a/src/applications/application.routes.ts
+++ b/src/applications/application.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { ApplicationController } from './application.controller.js';
 import ApplicationService from '@/applications/application.service.js';
 import { requireAuth, requireRole } from '@/shared/middleware/auth.middleware.js';
+import { rateLimitViewIncrement } from '@/shared/middleware/rate-limit.middleware.js';
 import { db } from '@/shared/config/database.js';
 
 const router = Router();
@@ -126,10 +127,18 @@ router.post('/:id/claim', requireAuth, applicationController.claimApplication);
 router.get('/:slug/edit', requireAuth, applicationController.getOwnApplicationBySlug);
 
 /**
+ * @route POST /api/applications/:slug/view
+ * @description Increment application view count
+ * @access Public (Rate-limited)
+ */
+router.post('/:slug/view', rateLimitViewIncrement, applicationController.incrementViewCount);
+
+/**
  * @route GET /api/applications/:slug
  * @description Get a single application by slug
  * @access Public
  */
 router.get('/:slug', applicationController.getApplicationBySlug);
+
 
 export default router;

--- a/src/applications/application.service.ts
+++ b/src/applications/application.service.ts
@@ -60,7 +60,7 @@ export interface IApplicationService {
     id: number,
     updates: PatchApplicationRequest,
     actorUserId: string,
-    role: string
+    role: string,
   ): Promise<string>;
   reviewAdminApplicationById(id: number, input: ReviewApplicationRequest): Promise<void>;
   deleteApplicationById(id: number, actorUserId: string): Promise<void>;
@@ -83,6 +83,7 @@ export interface IApplicationService {
   ): Promise<void>;
   getAdminClaimRequests(query: AdminClaimsListQuery): Promise<ClaimRequestsListResponse>;
   reviewAdminClaimRequest(claimId: number, input: ReviewClaimRequest): Promise<void>;
+  incrementViewCount(slug: string): Promise<void>; 
 }
 
 export default class ApplicationService implements IApplicationService {
@@ -173,24 +174,45 @@ export default class ApplicationService implements IApplicationService {
       );
     }
 
-    let orderByColumn:
-      | typeof application.createdAt
-      | typeof application.updatedAt
-      | typeof application.title;
+    // Popularity & standard sort expressions
+    const favoritesCountExpr = sql`count(distinct ${userFavorite.userId})`;
+    const ratingCountExpr = sql`count(distinct ${rating.userId})`;
+    const avgRatingExpr = sql`avg(${rating.score})`;
+
+    let orderByClause: SQL;
     switch (sortBy) {
       case 'title':
-        orderByColumn = application.title;
+        orderByClause = sortOrder === 'asc' ? asc(application.title) : desc(application.title);
         break;
       case 'updatedAt':
-        orderByColumn = application.updatedAt;
+        orderByClause = sortOrder === 'asc' ? asc(application.updatedAt) : desc(application.updatedAt);
+        break;
+      case 'viewCount':
+        orderByClause = sortOrder === 'asc' ? asc(application.viewCount) : desc(application.viewCount);
+        break;
+      case 'favoritesCount':
+        orderByClause =
+          sortOrder === 'asc'
+            ? sql`${favoritesCountExpr} ASC, ${application.id} ASC`
+            : sql`${favoritesCountExpr} DESC, ${application.id} DESC`;
+        break;
+      case 'ratingCount':
+        orderByClause =
+          sortOrder === 'asc'
+            ? sql`${ratingCountExpr} ASC, ${application.id} ASC`
+            : sql`${ratingCountExpr} DESC, ${application.id} DESC`;
+        break;
+      case 'averageRating':
+        orderByClause =
+          sortOrder === 'asc'
+            ? sql`${avgRatingExpr} ASC NULLS FIRST, ${application.id} ASC`
+            : sql`${avgRatingExpr} DESC NULLS LAST, ${application.id} DESC`;
         break;
       case 'createdAt':
       default:
-        orderByColumn = application.createdAt;
+        orderByClause = sortOrder === 'asc' ? asc(application.createdAt) : desc(application.createdAt);
         break;
     }
-
-    const orderByClause = sortOrder === 'asc' ? asc(orderByColumn) : desc(orderByColumn);
 
     const whereClause = and(...conditions);
 
@@ -228,6 +250,20 @@ export default class ApplicationService implements IApplicationService {
         totalPages,
       },
     };
+  };
+
+  incrementViewCount = async (slug: string): Promise<void> => {
+    const [result] = await this.db
+      .update(application)
+      .set({
+        viewCount: sql`${application.viewCount} + 1`,
+      })
+      .where(and(eq(application.slug, slug), eq(application.status, 'APPROVED')))
+      .returning({ id: application.id });
+
+    if (!result) {
+      throw new HttpError(404, 'Application not found', 'NOT_FOUND');
+    }
   };
 
   getApplicationBySlug = async (slug: string): Promise<ApplicationResponse> => {
@@ -295,18 +331,16 @@ export default class ApplicationService implements IApplicationService {
       userId: actorUserId,
       status: 'PENDING',
       rejectionReason: null,
+      viewCount: 0,
     });
-
-    return;
   };
 
   patchApplicationById = async (
     id: number,
     updates: PatchApplicationRequest,
     actorUserId: string,
-    role: string 
+    role: string,
   ): Promise<string> => {
-
     if (Object.keys(updates).length === 0) {
       return this.getApplicationSlugById(id);
     }
@@ -321,9 +355,7 @@ export default class ApplicationService implements IApplicationService {
       throw new HttpError(404, 'Application not found', 'NOT_FOUND');
     }
 
-    //Throws if not admin or the user is messing with another person's app
-    assertOwnershipOrAdmin(actorUserId, current.userId, role)
-
+    assertOwnershipOrAdmin(actorUserId, current.userId, role);
 
     const setPayload: PatchApplicationRequest & { status?: typeof application.status._.data } = {
       ...updates,
@@ -333,7 +365,6 @@ export default class ApplicationService implements IApplicationService {
       setPayload.status = 'PENDING';
     }
 
-    // Collect replaced S3 keys so they can be deleted after the DB update succeeds.
     const orphanedKeys: Array<string | null | undefined> = [];
 
     if (updates.icon !== undefined && updates.icon !== current.icon) {
@@ -359,9 +390,7 @@ export default class ApplicationService implements IApplicationService {
         .returning({ slug: application.slug });
     } catch (error) {
       const { message, constraint } = getDbErrorMessage(error);
-
       console.error('Database operation failed:', { message, constraint, originalError: error });
-
       throw new HttpError(409, 'Application with this slug already exists', 'DUPLICATE_SLUG');
     }
 
@@ -376,9 +405,6 @@ export default class ApplicationService implements IApplicationService {
     return patched.slug;
   };
 
-  /**
-   * Approve or reject an application (admin action)
-   */
   reviewAdminApplicationById = async (
     id: number,
     input: ReviewApplicationRequest,
@@ -431,8 +457,6 @@ export default class ApplicationService implements IApplicationService {
       })
       .where(eq(application.id, id))
       .returning();
-
-    return;
   };
 
   deleteApplicationById = async (id: number, actorUserId: string): Promise<void> => {
@@ -585,7 +609,6 @@ export default class ApplicationService implements IApplicationService {
     const offset = (page - 1) * limit;
 
     const statusCondition = status ? eq(applicationClaimRequest.status, status) : undefined;
-
     const whereClause = statusCondition ?? sql`1=1`;
 
     const [{ total }] = await this.db
@@ -728,5 +751,4 @@ export default class ApplicationService implements IApplicationService {
 
     return !!result;
   };
-
 }

--- a/src/applications/dto/application-response.dto.ts
+++ b/src/applications/dto/application-response.dto.ts
@@ -33,6 +33,7 @@ export const ApplicationResponseSchema = z
     favoritesCount: z.number().int().nonnegative().openapi({ example: 12 }),
     ratingCount: z.number().int().nonnegative().openapi({ example: 5 }),
     averageRating: z.number().nullable().openapi({ example: 4.2 }),
+    viewCount: z.number().int().nonnegative().openapi({ example: 42 }),
   })
   .openapi('ApplicationResponse');
 

--- a/src/applications/dto/applications-list-query.dto.ts
+++ b/src/applications/dto/applications-list-query.dto.ts
@@ -50,7 +50,15 @@ export const ApplicationsListQuerySchema = z
 
     // Sorting options
     sortBy: z
-      .enum(['createdAt', 'updatedAt', 'title'])
+      .enum([
+        'createdAt',
+        'updatedAt',
+        'title',
+        'viewCount',
+        'favoritesCount',
+        'ratingCount',
+        'averageRating',
+      ])
       .default(APPLICATION_CONSTANTS.DEFAULT_SORT_BY)
       .nullish()
       .openapi({ example: 'createdAt', description: 'Field to sort by' }),

--- a/src/applications/tests/application.service.test.ts
+++ b/src/applications/tests/application.service.test.ts
@@ -9,6 +9,7 @@ import { PgliteDatabase } from 'drizzle-orm/pglite';
 import { PGlite } from '@electric-sql/pglite';
 import { eq } from 'drizzle-orm';
 import { userFavorite } from '@/favorites/favorites.model.js';
+import { rating } from '@/ratings/rating.model.js';
 
 describe('ApplicationService', () => {
   let service: ApplicationService;
@@ -527,6 +528,108 @@ describe('ApplicationService', () => {
 
       expect(result.id).toBe(app.id);
       expect(result.title).toBe('Title');
+    });
+  });
+
+  describe('Popularity-Based Sorting', () => {
+    it('should sort applications by viewCount ascending and descending', async () => {
+      const app1 = await createTestApp({ slug: 'views-1', viewCount: 10 });
+      const app2 = await createTestApp({ slug: 'views-2', viewCount: 50 });
+      const app3 = await createTestApp({ slug: 'views-3', viewCount: 5 });
+
+      const descResult = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'viewCount',
+        sortOrder: 'desc',
+      });
+      expect(descResult.data.map((a) => a.slug)).toEqual([app2.slug, app1.slug, app3.slug]);
+
+      const ascResult = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'viewCount',
+        sortOrder: 'asc',
+      });
+      expect(ascResult.data.map((a) => a.slug)).toEqual([app3.slug, app1.slug, app2.slug]);
+    });
+
+    it('should sort applications by favoritesCount', async () => {
+      const app1 = await createTestApp({ slug: 'favs-1' });
+      const app2 = await createTestApp({ slug: 'favs-2' });
+
+      // app2 gets 2 favorites, app1 gets 1 favorite
+      await db.insert(userFavorite).values([
+        { userId: testUserId, applicationId: app1.id },
+        { userId: testUserId, applicationId: app2.id },
+        { userId: otherUserId, applicationId: app2.id },
+      ]);
+
+      const descResult = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'favoritesCount',
+        sortOrder: 'desc',
+      });
+      expect(descResult.data[0].slug).toBe(app2.slug);
+      expect(descResult.data[1].slug).toBe(app1.slug);
+
+      const ascResult = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'favoritesCount',
+        sortOrder: 'asc',
+      });
+      expect(ascResult.data[0].slug).toBe(app1.slug);
+      expect(ascResult.data[1].slug).toBe(app2.slug);
+    });
+
+    it('should sort applications by ratingCount and averageRating', async () => {
+      const app1 = await createTestApp({ slug: 'rating-1' });
+      const app2 = await createTestApp({ slug: 'rating-2' });
+
+      // app1: score 5.0 (1 rating)
+      // app2: score 3.0, 4.0 -> average 3.5 (2 ratings)
+      await db.insert(rating).values([
+        { userId: testUserId, applicationId: app1.id, score: 5.0 },
+        { userId: testUserId, applicationId: app2.id, score: 3.0 },
+        { userId: otherUserId, applicationId: app2.id, score: 4.0 },
+      ]);
+
+      const ratingCountDesc = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'ratingCount',
+        sortOrder: 'desc',
+      });
+      expect(ratingCountDesc.data[0].slug).toBe(app2.slug);
+
+      const avgRatingDesc = await service.getPaginatedApplications(10, 1, {
+        sortBy: 'averageRating',
+        sortOrder: 'desc',
+      });
+      expect(avgRatingDesc.data[0].slug).toBe(app1.slug);
+    });
+  });
+
+  describe('incrementViewCount', () => {
+    it('should increment view count by 1 for approved applications', async () => {
+      const app = await createTestApp({ slug: 'view-target', viewCount: 0 });
+
+      await service.incrementViewCount(app.slug);
+
+      const updated = await service.getApplicationBySlug(app.slug);
+      expect(updated.viewCount).toBe(1);
+
+      await service.incrementViewCount(app.slug);
+      const updatedAgain = await service.getApplicationBySlug(app.slug);
+      expect(updatedAgain.viewCount).toBe(2);
+    });
+
+    it('should throw 404 when incrementing views for non-existent app', async () => {
+      await expect(service.incrementViewCount('non-existent-app')).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'NOT_FOUND',
+      });
+    });
+
+    it('should throw 404 when application is not approved', async () => {
+      const pendingApp = await createTestApp({ slug: 'pending-view-app', status: 'PENDING' });
+
+      await expect(service.incrementViewCount(pendingApp.slug)).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'NOT_FOUND',
+      });
     });
   });
 });

--- a/src/shared/infrastructure/database/schema.ts
+++ b/src/shared/infrastructure/database/schema.ts
@@ -66,6 +66,7 @@ export const application = pgTable(
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
+    viewCount: integer('view_count').default(0).notNull(),
   },
   (table) => [
     index('application_user_id_idx').on(table.userId),
@@ -78,6 +79,7 @@ export const application = pgTable(
       foreignColumns: [user.id],
       name: 'applications_user_id_users_id_fk',
     }).onDelete('cascade'),
+    index('application_view_count_idx').on(table.viewCount),
   ],
 );
 

--- a/src/shared/infrastructure/database/schema.ts
+++ b/src/shared/infrastructure/database/schema.ts
@@ -61,12 +61,12 @@ export const application = pgTable(
     status: applicationApprovalStatus('status').default('PENDING').notNull(),
     rejectionReason: text('rejection_reason'),
     unclaimed: boolean('unclaimed').notNull().default(false),
+    viewCount: integer('view_count').default(0).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
-    viewCount: integer('view_count').default(0).notNull(),
   },
   (table) => [
     index('application_user_id_idx').on(table.userId),
@@ -74,12 +74,12 @@ export const application = pgTable(
     index('application_updated_at_idx').on(table.updatedAt),
     index('application_title_idx').on(table.title),
     index('application_status_idx').on(table.status),
+    index('application_view_count_idx').on(table.viewCount),
     foreignKey({
       columns: [table.userId],
       foreignColumns: [user.id],
       name: 'applications_user_id_users_id_fk',
     }).onDelete('cascade'),
-    index('application_view_count_idx').on(table.viewCount),
   ],
 );
 

--- a/src/shared/middleware/rate-limit.middleware.ts
+++ b/src/shared/middleware/rate-limit.middleware.ts
@@ -1,0 +1,45 @@
+import type { Request, Response, NextFunction } from 'express';
+import { HttpError } from './error.middleware.js';
+
+interface RateLimitRecord {
+  timestamp: number;
+}
+
+const viewRateLimitStore = new Map<string, RateLimitRecord>();
+
+// Clean up stale entries every 5 minutes
+const cleanupInterval = setInterval(() => {
+  const now = Date.now();
+  const windowMs = 60 * 1000;
+  for (const [key, record] of viewRateLimitStore.entries()) {
+    if (now - record.timestamp > windowMs) {
+      viewRateLimitStore.delete(key);
+    }
+  }
+}, 5 * 60 * 1000);
+
+cleanupInterval.unref();
+
+export const rateLimitViewIncrement = (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void => {
+  const ip = req.ip || req.socket.remoteAddress || 'unknown';
+  const slug = req.params.slug;
+  const key = `${ip}:${slug}`;
+  const now = Date.now();
+  const windowMs = 60 * 1000; // 1 minute per IP per app
+
+  const record = viewRateLimitStore.get(key);
+  if (record && now - record.timestamp < windowMs) {
+    throw new HttpError(429, 'Too many requests. Please try again later.', 'RATE_LIMITED');
+  }
+
+  viewRateLimitStore.set(key, { timestamp: now });
+  next();
+};
+
+export const _clearViewRateLimitStore = (): void => {
+  viewRateLimitStore.clear();
+};


### PR DESCRIPTION
## Summary
- This PR introduced a `viewCount` to application response DTOs and tests for sort options and incrementing endpoint
- Also creates rate-limiting middleware according to requirement "Rate limiting prevents view count abuse" & "Rate limit view endpoint (e.g., 1 per IP per minute per app)"

## Linked Issues
- closes #51  

## Notes for Reviewers
- Unsure if all tests have been implemented properly, will be updated as needed. The repository did not have any rate-limiting library (like express-rate-limit or Redis) installed. A lightweight in-memory middleware was needed to satisfy the requirement without adding heavy infrastructure dependencies.

